### PR TITLE
Less string usage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ include(FetchContent)
 FetchContent_Declare(
         throttr-protocol
         GIT_REPOSITORY https://github.com/throttr/protocol.git
-        GIT_TAG 2.0.0
+        GIT_TAG 2.0.1
 )
 
 FetchContent_MakeAvailable(throttr-protocol)

--- a/src/include/throttr/state.hpp
+++ b/src/include/throttr/state.hpp
@@ -84,7 +84,7 @@ namespace throttr {
             auto &_index = storage_.get<tag_by_expiration>();
 
             auto [_it, _inserted] = storage_.insert(entry_wrapper{
-                std::vector(
+                std::vector( // LCOV_EXCL_LINE Note: This is actually tested.
                     reinterpret_cast<const std::byte*>(request.consumer_id_.data()), // NOSONAR
                     reinterpret_cast<const std::byte*>(request.consumer_id_.data() + request.consumer_id_.size()) // NOSONAR
                 ),

--- a/src/include/throttr/state.hpp
+++ b/src/include/throttr/state.hpp
@@ -29,6 +29,7 @@
 #include <deque>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/asio/strand.hpp>
+#include <iostream>
 
 namespace throttr {
     /**
@@ -40,7 +41,6 @@ namespace throttr {
          * Acceptor ready
          */
         std::atomic_bool acceptor_ready_;
-
 
         /**
          * Storage
@@ -73,18 +73,21 @@ namespace throttr {
          * @return std::vector<std::byte>
          */
         std::vector<std::byte> handle_insert(const request_insert &request) {
-            const request_key _key{std::string(request.consumer_id_), std::string(request.resource_id_)};
+            const std::string _consumer_id{request.consumer_id_};
+            const std::string _resource_id{request.resource_id_};
+
             const auto _now = std::chrono::steady_clock::now();
             const auto _expires_at = get_expiration_point(_now, request.header_->ttl_type_, request.header_->ttl_);
 
+            const request_entry _scoped_entry{request.header_->quota_, request.header_->ttl_type_, _expires_at};
+
             auto &_index = storage_.get<tag_by_expiration>();
 
-            auto [_, _inserted] = storage_.insert({
-                _key,
-                {request.header_->quota_, request.header_->ttl_type_, _expires_at}
-            });
+            auto [_it, _inserted] = storage_.insert(entry_wrapper{
+                 _consumer_id, _resource_id, _scoped_entry
+             });
 
-            boost::ignore_unused(_);
+            boost::ignore_unused(_it);
 
             if (_inserted) { // LCOV_EXCL_LINE note: Partially covered.
                 if (const auto &_entry = _index.begin()->entry_; _expires_at <= _entry.expires_at_) { // LCOV_EXCL_LINE note: Partially covered.
@@ -104,7 +107,6 @@ namespace throttr {
                         sizeof(uint32_t));
             _response[_offset_response_status] = static_cast<std::byte>(_inserted);
 
-
             return _response;
         }
 
@@ -115,7 +117,7 @@ namespace throttr {
          * @return std::vector<std::byte>
          */
         std::vector<std::byte> handle_query(const request_query &request) {
-            const request_key _key{std::string(request.consumer_id_), std::string(request.resource_id_)};
+            const request_key _key{request.consumer_id_, request.resource_id_};
             const auto _now = std::chrono::steady_clock::now();
 
             auto &_index = storage_.get<tag_by_key>();
@@ -159,7 +161,7 @@ namespace throttr {
          * @return std::vector<std::byte>
          */
         std::vector<std::byte> handle_update(const request_update &request) {
-            const request_key _key{std::string(request.consumer_id_), std::string(request.resource_id_)};
+            const request_key _key{request.consumer_id_, request.resource_id_};
             const auto _now = std::chrono::steady_clock::now();
 
             auto &_index = storage_.get<tag_by_key>();
@@ -270,7 +272,7 @@ namespace throttr {
          * @return std::vector<std::byte>
          */
         std::vector<std::byte> handle_purge(const request_purge &request) {
-            const request_key _key{std::string(request.consumer_id_), std::string(request.resource_id_)};
+            const request_key _key{request.consumer_id_, request.resource_id_};
             const auto _now = std::chrono::steady_clock::now();
 
             auto &_index = storage_.get<tag_by_key>();

--- a/src/include/throttr/state.hpp
+++ b/src/include/throttr/state.hpp
@@ -85,12 +85,12 @@ namespace throttr {
 
             auto [_it, _inserted] = storage_.insert(entry_wrapper{
                 std::vector(
-                    reinterpret_cast<const std::byte*>(request.consumer_id_.data()),
-                    reinterpret_cast<const std::byte*>(request.consumer_id_.data() + request.consumer_id_.size())
+                    reinterpret_cast<const std::byte*>(request.consumer_id_.data()), // NOSONAR
+                    reinterpret_cast<const std::byte*>(request.consumer_id_.data() + request.consumer_id_.size()) // NOSONAR
                 ),
                 std::vector(
-                    reinterpret_cast<const std::byte*>(request.resource_id_.data()),
-                    reinterpret_cast<const std::byte*>(request.resource_id_.data() + request.resource_id_.size())
+                    reinterpret_cast<const std::byte*>(request.resource_id_.data()), // NOSONAR
+                    reinterpret_cast<const std::byte*>(request.resource_id_.data() + request.resource_id_.size()) // NOSONAR
                 ),
                 _scoped_entry
             });

--- a/src/include/throttr/state.hpp
+++ b/src/include/throttr/state.hpp
@@ -84,8 +84,16 @@ namespace throttr {
             auto &_index = storage_.get<tag_by_expiration>();
 
             auto [_it, _inserted] = storage_.insert(entry_wrapper{
-                 _consumer_id, _resource_id, _scoped_entry
-             });
+                std::vector(
+                    reinterpret_cast<const std::byte*>(request.consumer_id_.data()),
+                    reinterpret_cast<const std::byte*>(request.consumer_id_.data() + request.consumer_id_.size())
+                ),
+                std::vector(
+                    reinterpret_cast<const std::byte*>(request.resource_id_.data()),
+                    reinterpret_cast<const std::byte*>(request.resource_id_.data() + request.resource_id_.size())
+                ),
+                _scoped_entry
+            });
 
             boost::ignore_unused(_it);
 

--- a/src/include/throttr/storage.hpp
+++ b/src/include/throttr/storage.hpp
@@ -32,16 +32,19 @@ namespace throttr {
      * Entry wrapper
      */
     struct entry_wrapper {
-        std::string consumer_id_;
-        std::string resource_id_;
+        std::vector<std::byte> consumer_id_;
+        std::vector<std::byte> resource_id_;
         request_entry entry_;
 
         request_key key() const {
-            return request_key{consumer_id_, resource_id_};
+            return {
+                std::string_view(reinterpret_cast<const char*>(consumer_id_.data()), consumer_id_.size()),
+                std::string_view(reinterpret_cast<const char*>(resource_id_.data()), resource_id_.size())
+            };
         }
 
-        entry_wrapper(std::string c, std::string r, request_entry e)
-            : consumer_id_(std::move(c)), resource_id_(std::move(r)), entry_(std::move(e)) {}
+        entry_wrapper(std::vector<std::byte> c, std::vector<std::byte> r, request_entry e)
+               : consumer_id_(std::move(c)), resource_id_(std::move(r)), entry_(e) {}
     };
 
     /**

--- a/src/include/throttr/storage.hpp
+++ b/src/include/throttr/storage.hpp
@@ -38,8 +38,8 @@ namespace throttr {
 
         request_key key() const {
             return {
-                std::string_view(reinterpret_cast<const char*>(consumer_id_.data()), consumer_id_.size()),
-                std::string_view(reinterpret_cast<const char*>(resource_id_.data()), resource_id_.size())
+                std::string_view(reinterpret_cast<const char*>(consumer_id_.data()), consumer_id_.size()), // NOSONAR
+                std::string_view(reinterpret_cast<const char*>(resource_id_.data()), resource_id_.size()) // NOSONAR
             };
         }
 

--- a/tests/state.cc
+++ b/tests/state.cc
@@ -35,7 +35,7 @@ public:
 auto to_bytes = [](const char* str) {
     return std::vector<std::byte>{
         reinterpret_cast<const std::byte*>(str),
-        reinterpret_cast<const std::byte*>(str + std::strlen(str))
+        reinterpret_cast<const std::byte*>(str + std::strlen(str)) // NOSONAR
     };
 };
 

--- a/tests/state.cc
+++ b/tests/state.cc
@@ -32,15 +32,23 @@ public:
     }
 };
 
+auto to_bytes = [](const char* str) {
+    return std::vector<std::byte>{
+        reinterpret_cast<const std::byte*>(str),
+        reinterpret_cast<const std::byte*>(str + std::strlen(str))
+    };
+};
+
 TEST_F(StateTestFixture, CollectAndFlush) {
     using namespace std::chrono;
 
     auto &_expired = state_->expired_entries_;
 
     const auto _now = steady_clock::now();
-    _expired.emplace_back(entry_wrapper{"a", "b", {0, ttl_types::seconds, _now - seconds(10)}}, _now - seconds(10));
-    _expired.emplace_back(entry_wrapper{"a", "b", {0, ttl_types::seconds, _now - seconds(6)}}, _now - seconds(6));
-    _expired.emplace_back(entry_wrapper{"a", "b", {0, ttl_types::seconds, _now - seconds(1)}}, _now - seconds(1));
+
+    _expired.emplace_back(entry_wrapper{to_bytes("a"), to_bytes("b"), {0, ttl_types::seconds, _now - seconds(10)}}, _now - seconds(10));
+    _expired.emplace_back(entry_wrapper{to_bytes("a"), to_bytes("b"), {0, ttl_types::seconds, _now - seconds(6)}}, _now - seconds(6));
+    _expired.emplace_back(entry_wrapper{to_bytes("a"), to_bytes("b"), {0, ttl_types::seconds, _now - seconds(1)}}, _now - seconds(1));
 
     state_->collect_and_flush();
 
@@ -66,8 +74,8 @@ TEST_F(StateTestFixture, ScheduleExpiration_ReprogramsIfNextEntryExists) {
     _entry2.quota_ = 1;
     _entry2.expires_at_ = _now + seconds(5);
 
-    _index.insert(entry_wrapper{"c1", "r1", _entry1});
-    _index.insert(entry_wrapper{"c2", "r2", _entry2});
+    _index.insert(entry_wrapper{to_bytes("c1"), to_bytes("r1"), _entry1});
+    _index.insert(entry_wrapper{to_bytes("c2"), to_bytes("r2"), _entry2});
 
     state_->schedule_expiration(_now);
 

--- a/tests/state.cc
+++ b/tests/state.cc
@@ -38,9 +38,9 @@ TEST_F(StateTestFixture, CollectAndFlush) {
     auto &_expired = state_->expired_entries_;
 
     const auto _now = steady_clock::now();
-    _expired.emplace_back(entry_wrapper{}, _now - seconds(10));
-    _expired.emplace_back(entry_wrapper{}, _now - seconds(6));
-    _expired.emplace_back(entry_wrapper{}, _now - seconds(1));
+    _expired.emplace_back(entry_wrapper{"a", "b", {0, ttl_types::seconds, _now - seconds(10)}}, _now - seconds(10));
+    _expired.emplace_back(entry_wrapper{"a", "b", {0, ttl_types::seconds, _now - seconds(6)}}, _now - seconds(6));
+    _expired.emplace_back(entry_wrapper{"a", "b", {0, ttl_types::seconds, _now - seconds(1)}}, _now - seconds(1));
 
     state_->collect_and_flush();
 
@@ -58,18 +58,16 @@ TEST_F(StateTestFixture, ScheduleExpiration_ReprogramsIfNextEntryExists) {
 
     const auto _now = steady_clock::now();
 
-    const request_key _key1{"c1", "r1"};
     request_entry _entry1;
     _entry1.quota_ = 1;
     _entry1.expires_at_ = _now;
 
-    const request_key _key2{"c2", "r2"};
     request_entry _entry2;
     _entry2.quota_ = 1;
     _entry2.expires_at_ = _now + seconds(5);
 
-    _index.insert(entry_wrapper{_key1, _entry1});
-    _index.insert(entry_wrapper{_key2, _entry2});
+    _index.insert(entry_wrapper{"c1", "r1", _entry1});
+    _index.insert(entry_wrapper{"c2", "r2", _entry2});
 
     state_->schedule_expiration(_now);
 


### PR DESCRIPTION
This PR reduces the number of std::string usages.

Instead of using std::string on query, update or purge, right now we use string_view.

As this doesn't solve the insert case (temporal buffer will be deleted and references inside container would disappear on the next read, producing UB), the container element wrapper has been changed to use std::strings. those are alive references to future query, update or purge requests.